### PR TITLE
Fix possible call to undefined object

### DIFF
--- a/.active_content_sandbox/store/resource/cachedResources/index.html
+++ b/.active_content_sandbox/store/resource/cachedResources/index.html
@@ -62,10 +62,13 @@
         hax()
 
         function hax() {
-            kindle.device.clearApplicationCache();
-            kindle.device.clearCache();
-            kindle.dev.clearApplicationCache();
-            kindle.dev.clearCache();
+            if (kindle.device !== undefined) {
+                kindle.device.clearApplicationCache();
+                kindle.device.clearCache();
+            } else if (kindle.dev !== undefined) {
+                kindle.dev.clearApplicationCache();
+                kindle.dev.clearCache();
+            }
 
             kindle.chrome.setSpinnerState('stop', 0, 0);
             kindle.net.setWirelessPrompt('never');


### PR DESCRIPTION
Mesquito wouldn't start on my Paperwhite Gen 1. With some debugging I figured out, that kindle.device was undefined but kindle.dev did exist as an object.
To make the app work in such cases, the call to kindle.dev and kindle.device are now wrapped in a check to make sure none of them are undefined before trying to call functions on them.